### PR TITLE
Update to open-sdg 0.2.0 so that the Twitter link won't show

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,4 +85,4 @@ defaults:
 plugins:
   - jekyll-remote-theme
 
-remote_theme: open-sdg/open-sdg@0.1.0
+remote_theme: open-sdg/open-sdg@0.2.0

--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -85,4 +85,4 @@ defaults:
 plugins:
   - jekyll-remote-theme
 
-remote_theme: open-sdg/open-sdg@0.1.0
+remote_theme: open-sdg/open-sdg@0.2.0


### PR DESCRIPTION
In the latest version of Open SDG (0.2.0) the Twitter link is configurable. It can be set with the `twitter` field in `_config.yml`. If that field is not there, the Twitter link will not display (which is the intention here). This avoids the trouble of overriding the footer just to change/hide the Twitter link.